### PR TITLE
fix: keep notary table menu open until outside click

### DIFF
--- a/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.html
+++ b/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.html
@@ -16,15 +16,18 @@
       <div *ngIf="openMenuId === element.idParametrosFacturacionNotarias"
            class="inline-row-menu"
            (click)="$event.stopPropagation()">
-        <button mat-menu-item (click)="openEditFromInline(element.idParametrosFacturacionNotarias, 'general')">
+        <button mat-button class="menu-item"
+                (click)="openEditFromInline(element.idParametrosFacturacionNotarias, 'general')">
           <mat-icon>edit</mat-icon>
           <span>Editar parámetros</span>
         </button>
-        <button mat-menu-item (click)="openEditFromInline(element.idParametrosFacturacionNotarias, 'logo')">
+        <button mat-button class="menu-item"
+                (click)="openEditFromInline(element.idParametrosFacturacionNotarias, 'logo')">
           <mat-icon>image</mat-icon>
           <span>Editar logo</span>
         </button>
-        <button mat-menu-item (click)="openEditFromInline(element.idParametrosFacturacionNotarias, 'sign')">
+        <button mat-button class="menu-item"
+                (click)="openEditFromInline(element.idParametrosFacturacionNotarias, 'sign')">
           <mat-icon>edit_note</mat-icon>
           <span>Editar firma electrónica</span>
         </button>

--- a/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.html
+++ b/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.html
@@ -9,6 +9,7 @@
     <th mat-header-cell *matHeaderCellDef> </th>
     <td mat-cell *matCellDef="let element" style="position: relative;">
       <button mat-icon-button aria-label="Acciones"
+              class="row-menu-button"
               (click)="$event.stopPropagation(); toggleRowMenu(element.idParametrosFacturacionNotarias)">
         <mat-icon>more_vert</mat-icon>
       </button>

--- a/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.scss
+++ b/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.scss
@@ -24,3 +24,12 @@
 .inline-row-menu .menu-item mat-icon {
   margin-right: 8px;
 }
+
+/* Ensure row menus can render outside the row/cell bounds */
+.mat-table,
+.mat-row,
+.mat-header-row,
+.mat-cell,
+.mat-header-cell {
+  overflow: visible;
+}

--- a/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.scss
+++ b/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.scss
@@ -16,6 +16,11 @@
   flex-direction: column;
 }
 
-.inline-row-menu button[mat-menu-item] {
+.inline-row-menu .menu-item {
   justify-content: flex-start;
+  width: 100%;
+}
+
+.inline-row-menu .menu-item mat-icon {
+  margin-right: 8px;
 }

--- a/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.ts
+++ b/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.ts
@@ -136,8 +136,14 @@ export class BillingParametersNotaryTableComponent implements OnInit{
   }
 
   @HostListener('document:click', ['$event'])
-  closeMenuOnOutsideClick(_: MouseEvent) {
-    this.openMenuId = null;
+  closeMenuOnOutsideClick(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    const clickedInsideMenu = target.closest('.inline-row-menu');
+    const clickedToggleButton = target.closest('.row-menu-button');
+
+    if (!clickedInsideMenu && !clickedToggleButton) {
+      this.openMenuId = null;
+    }
   }
 
   openEditGeneralParams(idParametrosFacturacionNotarias?: number) {

--- a/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.ts
+++ b/src/app/features/parametros/components/tables/billing-parameters-notary-table/billing-parameters-notary-table.component.ts
@@ -1,12 +1,12 @@
 import {Component, HostListener, OnInit} from '@angular/core';
 import {ParametrosFacturacionNotarias} from "../../../../../shared/interfaces/parametros-facturacion-notarias";
 import {NotariasPesnotService} from "../../../../../shared/services/notarias-pesnot.service";
+import {CommonModule} from "@angular/common";
 import {MatTableModule} from "@angular/material/table";
 import {UserSelected} from "../../../interfaces/user-selected";
 import {ToastrService} from "ngx-toastr";
 import {MatButtonModule} from "@angular/material/button";
 import {MatIconModule} from "@angular/material/icon";
-import {MatMenuModule} from "@angular/material/menu";
 import { MatDialog } from '@angular/material/dialog';
 import { CreateOrUpdateParametrosFacturacionNotariasModalComponent } from '../../modals/create-or-update-parametros-facturacion-notarias-modal/create-or-update-parametros-facturacion-notarias-modal.component';
 import { EditGeneralParamsBillingByIdModalComponent } from '../../modals/edit-general-params-billing-by-id-modal/edit-general-params-billing-by-id-modal.component';
@@ -18,10 +18,10 @@ import {RepositorioService} from "../../../../../shared/services/repositorio.ser
   selector: 'app-billing-parameters-notary-table',
   standalone: true,
   imports: [
+    CommonModule,
     MatTableModule,
     MatButtonModule,
     MatIconModule,
-    MatMenuModule,
   ],
   templateUrl: './billing-parameters-notary-table.component.html',
   styleUrl: './billing-parameters-notary-table.component.scss'


### PR DESCRIPTION
## Summary
- ensure inline menu in billing notaries table stays visible when opened
- close menu only when clicking outside the menu or trigger button

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: could not resolve dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c058296df08324b8022af52b0b41a4